### PR TITLE
Pokedex broken at startup

### DIFF
--- a/javascript/setup.js
+++ b/javascript/setup.js
@@ -29,7 +29,7 @@ async function getAllTypes() {
         for(j = 0; j < pokemonInType.length; j++) {
             const pokemonId = pokemonInType[j].pokemon.url.replace('https://pokeapi.co/api/v2/pokemon/', '').replace('/', '');
 
-            if(pokemonId <= pokemons.length) {
+            if(pokemonId <= pokemons.length && pokemons[pokemonId]) {
                 pokemons[pokemonId].types.push(responseAsJson.name);
             };
         };


### PR DESCRIPTION
When you want to get all the pokemon names from the API, you actually set the limit tp 898 but for some reasons the API return 899 pokemons.

So when you want to get the types pokemon you have a problem when doing : 
`if(pokemonId <= pokemons.length) {`

You can do `pokemons.length - 1` but you are not sure if tomorrow pokeapi decide to return 898 pokemons and not 899, so it will be better to just check if the id exist in your array IMO.